### PR TITLE
fixing bug in dockerfile - libraries not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 ENV SERVERNAME localhost 
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nginx nginx-plus-module-rtmp libnginx-mod-rtmp certbot python3-certbot-nginx
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nginx libnginx-mod-rtmp certbot python3-certbot-nginx
 RUN cd /etc/nginx
 
 COPY nginx.conf .


### PR DESCRIPTION
Trying to fix dockerfile library nginx-plus-module-rtmp not found